### PR TITLE
T7499: allow load from internal representation to avoid re-parsing

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -85,7 +85,8 @@ message Request {
 
   message Load {
     required string Location = 1;
-    optional ConfigFormat format = 2;
+    required bool cached = 2;
+    optional ConfigFormat format = 3;
   }
 
   message Merge {

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -91,7 +91,8 @@ message Request {
 
   message Merge {
     required string Location = 1;
-    optional ConfigFormat format = 2;
+    required bool destructive = 2;
+    optional ConfigFormat format = 3;
   }
 
   message Save {

--- a/src/session.ml
+++ b/src/session.ml
@@ -142,6 +142,16 @@ let load w s file cached =
     | Ok config ->
         validate_tree w config; {s with proposed_config=config;}
 
+let merge w s file destructive =
+    let ct = Vyos1x.Config_file.load_config file in
+    match ct with
+    | Error e -> raise (Session_error (Printf.sprintf "Error loading config: %s" e))
+    | Ok config ->
+        let () = validate_tree w config in
+        let merged = CD.tree_merge ~destructive:destructive s.proposed_config config
+        in
+        {s with proposed_config=merged;}
+
 let save w s file =
     let ct = w.running_config in
     let res = Vyos1x.Config_file.save_config ct file in

--- a/src/session.ml
+++ b/src/session.ml
@@ -127,8 +127,16 @@ let session_changed w s =
     let del_tree = CT.get_subtree diff ["del"] in
     (del_tree <> CT.default) || (add_tree <> CT.default)
 
-let load w s file =
-    let ct = Vyos1x.Config_file.load_config file in
+let load w s file cached =
+    let ct =
+        if cached then
+            try
+                Ok (IC.read_internal file)
+            with Vyos1x.Internal.Read_error e ->
+                Error e
+        else
+            Vyos1x.Config_file.load_config file
+    in
     match ct with
     | Error e -> raise (Session_error (Printf.sprintf "Error loading config: %s" e))
     | Ok config ->

--- a/src/session.ml
+++ b/src/session.ml
@@ -104,8 +104,12 @@ let set w s path =
             apply_cfg_op op s.proposed_config |>
             (fun c -> RT.set_tag_data w.reference_tree c path) |>
             (fun c -> RT.set_leaf_data w.reference_tree c path)
-        with CT.Useless_set ->
+        with
+        | CT.Useless_set ->
             raise (Session_error (Printf.sprintf "Useless set, path: %s" (string_of_op op)))
+        | CT.Duplicate_value ->
+            raise (Session_error (Printf.sprintf "Duplicate value, path: %s" (string_of_op op)))
+
     in
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 

--- a/src/session.mli
+++ b/src/session.mli
@@ -39,6 +39,8 @@ val session_changed : world -> session_data -> bool
 
 val load : world -> session_data -> string -> bool -> session_data
 
+val merge : world -> session_data -> string -> bool -> session_data
+
 val save : world -> session_data -> string -> session_data
 
 val get_value : world -> session_data -> string list -> string

--- a/src/session.mli
+++ b/src/session.mli
@@ -37,7 +37,7 @@ val discard : world -> session_data -> session_data
 
 val session_changed : world -> session_data -> bool
 
-val load : world -> session_data -> string -> session_data
+val load : world -> session_data -> string -> bool -> session_data
 
 val save : world -> session_data -> string -> session_data
 

--- a/src/vyconf_pbt.ml
+++ b/src/vyconf_pbt.ml
@@ -83,6 +83,7 @@ type request_rollback = {
 
 type request_load = {
   location : string;
+  cached : bool;
   format : request_config_format option;
 }
 
@@ -313,9 +314,11 @@ let rec default_request_rollback
 
 let rec default_request_load 
   ?location:((location:string) = "")
+  ?cached:((cached:bool) = false)
   ?format:((format:request_config_format option) = None)
   () : request_load  = {
   location;
+  cached;
   format;
 }
 
@@ -567,11 +570,13 @@ let default_request_rollback_mutable () : request_rollback_mutable = {
 
 type request_load_mutable = {
   mutable location : string;
+  mutable cached : bool;
   mutable format : request_config_format option;
 }
 
 let default_request_load_mutable () : request_load_mutable = {
   location = "";
+  cached = false;
   format = None;
 }
 
@@ -819,6 +824,7 @@ let rec pp_request_rollback fmt (v:request_rollback) =
 let rec pp_request_load fmt (v:request_load) = 
   let pp_i fmt () =
     Pbrt.Pp.pp_record_field ~first:true "location" Pbrt.Pp.pp_string fmt v.location;
+    Pbrt.Pp.pp_record_field ~first:false "cached" Pbrt.Pp.pp_bool fmt v.cached;
     Pbrt.Pp.pp_record_field ~first:false "format" (Pbrt.Pp.pp_option pp_request_config_format) fmt v.format;
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
@@ -1137,10 +1143,12 @@ let rec encode_pb_request_rollback (v:request_rollback) encoder =
 let rec encode_pb_request_load (v:request_load) encoder = 
   Pbrt.Encoder.string v.location encoder;
   Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.bool v.cached encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
   begin match v.format with
   | Some x -> 
     encode_pb_request_config_format x encoder;
-    Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+    Pbrt.Encoder.key 3 Pbrt.Varint encoder; 
   | None -> ();
   end;
   ()
@@ -1784,6 +1792,7 @@ let rec decode_pb_request_rollback d =
 let rec decode_pb_request_load d =
   let v = default_request_load_mutable () in
   let continue__= ref true in
+  let cached_is_set = ref false in
   let location_is_set = ref false in
   while !continue__ do
     match Pbrt.Decoder.key d with
@@ -1795,15 +1804,22 @@ let rec decode_pb_request_load d =
     | Some (1, pk) -> 
       Pbrt.Decoder.unexpected_payload "Message(request_load), field(1)" pk
     | Some (2, Pbrt.Varint) -> begin
-      v.format <- Some (decode_pb_request_config_format d);
+      v.cached <- Pbrt.Decoder.bool d; cached_is_set := true;
     end
     | Some (2, pk) -> 
       Pbrt.Decoder.unexpected_payload "Message(request_load), field(2)" pk
+    | Some (3, Pbrt.Varint) -> begin
+      v.format <- Some (decode_pb_request_config_format d);
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_load), field(3)" pk
     | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
   done;
+  begin if not !cached_is_set then Pbrt.Decoder.missing_field "cached" end;
   begin if not !location_is_set then Pbrt.Decoder.missing_field "location" end;
   ({
     location = v.location;
+    cached = v.cached;
     format = v.format;
   } : request_load)
 

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -90,6 +90,7 @@ type request_rollback = {
 
 type request_load = {
   location : string;
+  cached : bool;
   format : request_config_format option;
 }
 
@@ -315,6 +316,7 @@ val default_request_rollback :
 
 val default_request_load : 
   ?location:string ->
+  ?cached:bool ->
   ?format:request_config_format option ->
   unit ->
   request_load

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -96,6 +96,7 @@ type request_load = {
 
 type request_merge = {
   location : string;
+  destructive : bool;
   format : request_config_format option;
 }
 
@@ -324,6 +325,7 @@ val default_request_load :
 
 val default_request_merge : 
   ?location:string ->
+  ?destructive:bool ->
   ?format:request_config_format option ->
   unit ->
   request_merge

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -223,6 +223,14 @@ let load world token (req: request_load) =
         response_tmpl
     with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
 
+let merge world token (req: request_merge) =
+    try
+        let session = Session.merge world (find_session token) req.location req.destructive
+        in
+        Hashtbl.replace sessions token session;
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
 let save world token (req: request_save) =
     try
         let _ = Session.save world (find_session token) req.location
@@ -319,6 +327,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Session_changed r -> session_changed world t r
                     | Some t, Get_config r -> get_config world t r
                     | Some t, Load r -> load world t r
+                    | Some t, Merge r -> merge world t r
                     | Some t, Save r -> save world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -217,7 +217,7 @@ let discard world token (_req: request_discard) =
 
 let load world token (req: request_load) =
     try
-        let session = Session.load world (find_session token) req.location
+        let session = Session.load world (find_session token) req.location req.cached
         in
         Hashtbl.replace sessions token session;
         response_tmpl


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Useful for the matter at hand, update of config merge tools, but also needed elsewhere (vyconf commit-confirm, for example).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
