### PR TITLE
T7637: fix typo in commit update and relax error on redundant set

### DIFF
--- a/src/commit.ml
+++ b/src/commit.ml
@@ -181,7 +181,12 @@ let config_result_update c_data n_data =
     match r.success, n_data.source with
     | true, ADD ->
         let add = CT.get_subtree c_data.config_diff ["add"] in
-        let add_tree = CD.clone add (CT.default) n_data.path in
+        let path =
+            match n_data.tag_value with
+            | None -> n_data.path
+            | Some v -> n_data.path @ [v]
+        in
+        let add_tree = CD.clone add (CT.default) path in
         let config = CD.tree_union add_tree c_data.config_result in
         let result =
             { success = c_data.result.success && true;
@@ -190,7 +195,12 @@ let config_result_update c_data n_data =
         { c_data with config_result = config; result = result; }
     | false, DELETE ->
         let del = CT.get_subtree c_data.config_diff ["del"] in
-        let add_tree = CD.clone del (CT.default) n_data.path in
+        let path =
+            match n_data.tag_value with
+            | None -> n_data.path
+            | Some v -> n_data.path @ [v]
+        in
+        let add_tree = CD.clone del (CT.default) path in
         let config = CD.tree_union add_tree c_data.config_result in
         let result =
             { success = c_data.result.success && false;

--- a/src/session.ml
+++ b/src/session.ml
@@ -105,10 +105,7 @@ let set w s path =
             (fun c -> RT.set_tag_data w.reference_tree c path) |>
             (fun c -> RT.set_leaf_data w.reference_tree c path)
         with
-        | CT.Useless_set ->
-            raise (Session_error (Printf.sprintf "Useless set, path: %s" (string_of_op op)))
-        | CT.Duplicate_value ->
-            raise (Session_error (Printf.sprintf "Duplicate value, path: %s" (string_of_op op)))
+        | CT.Useless_set | CT.Duplicate_value -> s.proposed_config
 
     in
     {s with proposed_config=config; changeset=(op :: s.changeset)}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Note the following fix will not be available until libvyosconfig/vyos-1x commit hashes are updated, as usual. The latter updates may well wait until follow-on PRs are added.

Fix two errors apparent in smoketests:
(1) allow redundant set errors `Useless_set` and `Duplicate_value`, as may occur with automation; they may be seen in, for example, `test_interfaces_vxlan.py` at:
(a) https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/base_interfaces_test.py#L497-L498
https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/base_interfaces_test.py#L523-L524
`vyos.configsession.ConfigSessionError: Duplicate value, path: set interfaces vxlan vxlan10 remote "127.0.0.2"`
and
(b) https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_interfaces_vxlan.py#L299
https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_interfaces_vxlan.py#L305-L306
`vyos.configsession.ConfigSessionError: Useless set, path: set interfaces vxlan vxlan987 parameters vni-filter`
They are a no-op if allowed and if raised as error would be expected to break other common automation.

(2) more fundamental, but simply fixed, was an error when updating paths on the results of a commit without explicitly including tag_values (hence including all under path): this is apparent, for example, in `test_vxlan_external` in `test_interfaces_vxlan.py` where all tag values of a tag node would be added on update, irrespective of error:
https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_interfaces_vxlan.py#L156-L160
leading to an missed apply stage on delete/re-commit.

With the above fixes, all tests for `test_interfaces_vxlan.py` pass (but for the final `tearDown`, which will be addressed in a separate PR). Clearly this is not an isolated case, as both of the above issues affect tests throughout.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
