### PR TITLE
T7718: use revised validate_tree

### DIFF
--- a/src/session.ml
+++ b/src/session.ml
@@ -101,22 +101,13 @@ let set w s path =
     in
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 
-let prune_del_path node path =
-    if CT.is_tag_value node path then
-        let tag_path = Vyos1x.Util.drop_last path in
-        let terminal = VT.is_terminal_path node tag_path in
-        match terminal with
-        | true -> CT.delete node tag_path None
-        | false -> node
-    else node
-
 let delete w s path =
     let path, value = split_path w s path in
     let op = CfgDelete (path, value) in
     let config =
         try
             apply_cfg_op op s.proposed_config |>
-            (fun c -> prune_del_path c path)
+            (fun c -> CT.prune_delete c path)
         with
         | VT.Nonexistent_path | CT.No_such_value -> s.proposed_config
     in

--- a/src/session.ml
+++ b/src/session.ml
@@ -75,17 +75,8 @@ let validate w _s path =
         RT.validate_path D.(w.dirs.validators) w.reference_tree path
     with RT.Validation_error x -> raise (Session_error x)
 
-let validate_tree w' t =
-    let validate_path w out path =
-        let res =
-            try
-                RT.validate_path D.(w.dirs.validators) w.reference_tree path;
-                out
-            with RT.Validation_error x -> out ^ x
-        in res
-    in
-    let paths = CT.value_paths_of_tree t in
-    let out = List.fold_left (validate_path w') "" paths in
+let validate_tree w t =
+    let out = RT.validate_tree D.(w.dirs.validators) w.reference_tree t in
     match out with
     | "" -> ()
     | _ -> raise (Session_error out)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use revised `validate_tree` method, added in
https://github.com/vyos/vyos1x-config/pull/51

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Other (please describe): Internal change

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/51

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
