### PR TITLE
T8032: add translation of cli-shell-api sessionUnsaved

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -185,6 +185,10 @@ message Request {
     optional int32 dummy = 1;
   }
 
+  message ConfigUnsaved {
+    optional string file = 1;
+  }
+
 
   oneof msg {
     Prompt prompt = 1;
@@ -224,6 +228,7 @@ message Request {
     ResetEditLevel reset_edit_level = 35;
     GetEditLevel get_edit_level = 36;
     EditLevelRoot edit_level_root = 37;
+    ConfigUnsaved config_unsaved = 38;
   }
 }
 

--- a/src/session.mli
+++ b/src/session.mli
@@ -69,6 +69,8 @@ val merge : world -> session_data -> string -> bool -> session_data
 
 val save : world -> session_data -> string -> session_data
 
+val config_unsaved : world -> session_data -> string -> string -> bool
+
 val get_value : world -> session_data -> string list -> string
 
 val get_values : world -> session_data -> string list -> string list

--- a/src/vyconf_cli_compat.ml
+++ b/src/vyconf_cli_compat.ml
@@ -9,6 +9,7 @@ type op_t =
     | OpEditLevelRoot
     | OpShowConfig
     | OpSessionChanged
+    | OpConfigUnsaved
 
 let op_of_arg s =
     match s with
@@ -19,6 +20,7 @@ let op_of_arg s =
     | "editLevelAtRoot" -> OpEditLevelRoot
     | "showCfg" -> OpShowConfig
     | "sessionChanged" -> OpSessionChanged
+    | "sessionUnsaved" -> OpConfigUnsaved
     | _ -> failwith (Printf.sprintf "Unknown operation %s" s)
 
 let in_cli_config_session () =
@@ -88,6 +90,7 @@ let main op path =
         | OpEditLevelRoot -> edit_level_root c
         | OpShowConfig -> show_config c path
         | OpSessionChanged -> session_changed c
+        | OpConfigUnsaved -> config_unsaved c None
         end
     | Error e -> Error e |> Lwt.return
     in

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -221,3 +221,11 @@ let edit_level_root client =
     | Success -> Lwt.return (Ok "")
     | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let config_unsaved client file =
+    let req = Config_unsaved {file=file;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> Lwt.return (Ok "")
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -47,3 +47,5 @@ val reset_edit_level : t -> (string, string) result Lwt.t
 val get_edit_level : t -> (string, string) result Lwt.t
 
 val edit_level_root : t -> (string, string) result Lwt.t
+
+val config_unsaved : t -> string option -> (string, string) result Lwt.t

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -186,6 +186,10 @@ type request_edit_level_root = {
   dummy : int32 option;
 }
 
+type request_config_unsaved = {
+  file : string option;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -224,6 +228,7 @@ type request =
   | Reset_edit_level of request_reset_edit_level
   | Get_edit_level of request_get_edit_level
   | Edit_level_root of request_edit_level_root
+  | Config_unsaved of request_config_unsaved
 
 type request_envelope = {
   token : string option;
@@ -500,6 +505,12 @@ val default_request_edit_level_root :
   request_edit_level_root
 (** [default_request_edit_level_root ()] is the default value for type [request_edit_level_root] *)
 
+val default_request_config_unsaved : 
+  ?file:string option ->
+  unit ->
+  request_config_unsaved
+(** [default_request_config_unsaved ()] is the default value for type [request_config_unsaved] *)
+
 val default_request : unit -> request
 (** [default_request ()] is the default value for type [request] *)
 
@@ -642,6 +653,9 @@ val pp_request_get_edit_level : Format.formatter -> request_get_edit_level -> un
 val pp_request_edit_level_root : Format.formatter -> request_edit_level_root -> unit 
 (** [pp_request_edit_level_root v] formats v *)
 
+val pp_request_config_unsaved : Format.formatter -> request_config_unsaved -> unit 
+(** [pp_request_config_unsaved v] formats v *)
+
 val pp_request : Format.formatter -> request -> unit 
 (** [pp_request v] formats v *)
 
@@ -774,6 +788,9 @@ val encode_pb_request_get_edit_level : request_get_edit_level -> Pbrt.Encoder.t 
 val encode_pb_request_edit_level_root : request_edit_level_root -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_edit_level_root v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_config_unsaved : request_config_unsaved -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_config_unsaved v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request v encoder] encodes [v] with the given [encoder] *)
 
@@ -905,6 +922,9 @@ val decode_pb_request_get_edit_level : Pbrt.Decoder.t -> request_get_edit_level
 
 val decode_pb_request_edit_level_root : Pbrt.Decoder.t -> request_edit_level_root
 (** [decode_pb_request_edit_level_root decoder] decodes a [request_edit_level_root] binary value from [decoder] *)
+
+val decode_pb_request_config_unsaved : Pbrt.Decoder.t -> request_config_unsaved
+(** [decode_pb_request_config_unsaved decoder] decodes a [request_config_unsaved] binary value from [decoder] *)
 
 val decode_pb_request : Pbrt.Decoder.t -> request
 (** [decode_pb_request decoder] decodes a [request] binary value from [decoder] *)

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -407,6 +407,16 @@ let edit_level_root world token (_req: request_edit_level_root) =
     if Session.edit_level_root world (find_session token) then response_tmpl
     else {response_tmpl with status=Fail}
 
+let config_unsaved world token (req: request_config_unsaved) =
+    let saved_file =
+        match req.file with
+        | None -> defaults.legacy_config_path
+        | Some file -> file
+    in
+    if Session.config_unsaved world (find_session token) saved_file token
+    then response_tmpl
+    else {response_tmpl with status=Fail}
+
 let send_response oc resp =
     let enc = Pbrt.Encoder.create () in
     let%lwt () = encode_pb_response resp enc |> return in
@@ -463,6 +473,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Reset_edit_level r -> reset_edit_level world t r
                     | Some t, Get_edit_level r -> get_edit_level world t r
                     | Some t, Edit_level_root r -> edit_level_root world t r
+                    | Some t, Config_unsaved r -> config_unsaved world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add analogue of `cli-shell-api sessionUnsaved` to `vyconf_cli_compat`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Other (please describe): vyconf integration with CLI

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
