### PR TITLE
T8061: Add requests of analogues of cli-shell-api completion functions

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -189,6 +189,9 @@ message Request {
     optional string file = 1;
   }
 
+  message ReferencePathExists {
+    repeated string path = 1;
+  }
 
   oneof msg {
     Prompt prompt = 1;
@@ -229,6 +232,7 @@ message Request {
     GetEditLevel get_edit_level = 36;
     EditLevelRoot edit_level_root = 37;
     ConfigUnsaved config_unsaved = 38;
+    ReferencePathExists reference_path_exists = 39;
   }
 }
 

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -198,6 +198,11 @@ message Request {
     required bool legacy_format = 2;
   }
 
+  message GetCompletionEnv {
+    repeated string path = 1;
+    required bool legacy_format = 2;
+  }
+
   oneof msg {
     Prompt prompt = 1;
     SetupSession setup_session = 2;
@@ -239,6 +244,7 @@ message Request {
     ConfigUnsaved config_unsaved = 38;
     ReferencePathExists reference_path_exists = 39;
     GetPathType get_path_type = 40;
+    GetCompletionEnv get_completion_env = 41;
   }
 }
 

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -193,6 +193,11 @@ message Request {
     repeated string path = 1;
   }
 
+  message GetPathType {
+    repeated string path = 1;
+    required bool legacy_format = 2;
+  }
+
   oneof msg {
     Prompt prompt = 1;
     SetupSession setup_session = 2;
@@ -233,6 +238,7 @@ message Request {
     EditLevelRoot edit_level_root = 37;
     ConfigUnsaved config_unsaved = 38;
     ReferencePathExists reference_path_exists = 39;
+    GetPathType get_path_type = 40;
   }
 }
 

--- a/src/session.ml
+++ b/src/session.ml
@@ -394,6 +394,9 @@ let config_unsaved w s file id =
 let reference_path_exists w _s path =
     RT.reference_path_exists w.reference_tree path
 
+let get_path_type ?(legacy_format=false) w _s path =
+    RT.get_path_type_str ~legacy_format w.reference_tree path
+
 let write_running_cache w =
     (* alert exn Internal.write_internal:
         [Internal.Write_error] caught

--- a/src/session.ml
+++ b/src/session.ml
@@ -391,6 +391,9 @@ let config_unsaved w s file id =
         with Session_error _ -> true (* false positive on unlikely error *)
     in remove_file tmp_save; res
 
+let reference_path_exists w _s path =
+    RT.reference_path_exists w.reference_tree path
+
 let write_running_cache w =
     (* alert exn Internal.write_internal:
         [Internal.Write_error] caught

--- a/src/session.ml
+++ b/src/session.ml
@@ -397,6 +397,20 @@ let reference_path_exists w _s path =
 let get_path_type ?(legacy_format=false) w _s path =
     RT.get_path_type_str ~legacy_format w.reference_tree path
 
+let get_completion_env ?(legacy_format=false) w s path =
+    let op, path =
+        match path with
+        | [] -> raise (Session_error "Missing op and path")
+        | h :: tl -> (h, tl)
+    in
+    let config = get_proposed_config w s in
+    let res =
+        Vyos1x.Completion.get_completion_env_str ~legacy_format w.reference_tree config op path
+    in
+    match res with
+    | Ok env -> env
+    | Error e -> raise (Session_error e)
+
 let write_running_cache w =
     (* alert exn Internal.write_internal:
         [Internal.Write_error] caught

--- a/src/session.mli
+++ b/src/session.mli
@@ -96,3 +96,5 @@ val cleanup_config : world -> string -> unit
 val show_config : world -> session_data -> string list -> string
 
 val reference_path_exists : world -> session_data -> string list -> bool
+
+val get_path_type : ?legacy_format:bool -> world -> session_data -> string list -> string

--- a/src/session.mli
+++ b/src/session.mli
@@ -94,3 +94,5 @@ val get_config : world -> session_data -> string -> string
 val cleanup_config : world -> string -> unit
 
 val show_config : world -> session_data -> string list -> string
+
+val reference_path_exists : world -> session_data -> string list -> bool

--- a/src/session.mli
+++ b/src/session.mli
@@ -98,3 +98,5 @@ val show_config : world -> session_data -> string list -> string
 val reference_path_exists : world -> session_data -> string list -> bool
 
 val get_path_type : ?legacy_format:bool -> world -> session_data -> string list -> string
+
+val get_completion_env : ?legacy_format:bool -> world -> session_data -> string list -> string

--- a/src/vyconf_cli_compat.ml
+++ b/src/vyconf_cli_compat.ml
@@ -12,6 +12,7 @@ type op_t =
     | OpConfigUnsaved
     | OpReferencePathExists
     | OpGetPathType
+    | OpGetCompletionEnv
 
 let op_of_arg s =
     match s with
@@ -25,6 +26,7 @@ let op_of_arg s =
     | "sessionUnsaved" -> OpConfigUnsaved
     | "validateTmplPath" -> OpReferencePathExists
     | "getNodeType" -> OpGetPathType
+    | "getCompletionEnv" -> OpGetCompletionEnv
     | _ -> failwith (Printf.sprintf "Unknown operation %s" s)
 
 let in_cli_config_session () =
@@ -97,6 +99,7 @@ let main op path =
         | OpConfigUnsaved -> config_unsaved c None
         | OpReferencePathExists -> reference_path_exists c path
         | OpGetPathType -> get_path_type c path
+        | OpGetCompletionEnv -> get_completion_env c path
         end
     | Error e -> Error e |> Lwt.return
     in
@@ -134,7 +137,11 @@ let () =
         with Failure msg -> let () = print_endline msg in exit 1
     in
     match op, path_list with
-    | OpSetEditLevel, [] | OpReferencePathExists, [] | OpGetPathType, [] ->
+    | OpSetEditLevel, []
+    | OpReferencePathExists, []
+    | OpGetPathType, [] ->
         let () = print_endline "Must specify config path" in exit 1
+    | OpGetCompletionEnv, [] | OpGetCompletionEnv, [_] ->
+        let () = print_endline "Must specify command and at least one component" in exit 1
     | _, _ ->
         let result = Lwt_main.run (main op path_list) in exit result

--- a/src/vyconf_cli_compat.ml
+++ b/src/vyconf_cli_compat.ml
@@ -10,6 +10,7 @@ type op_t =
     | OpShowConfig
     | OpSessionChanged
     | OpConfigUnsaved
+    | OpReferencePathExists
 
 let op_of_arg s =
     match s with
@@ -21,6 +22,7 @@ let op_of_arg s =
     | "showCfg" -> OpShowConfig
     | "sessionChanged" -> OpSessionChanged
     | "sessionUnsaved" -> OpConfigUnsaved
+    | "validateTmplPath" -> OpReferencePathExists
     | _ -> failwith (Printf.sprintf "Unknown operation %s" s)
 
 let in_cli_config_session () =
@@ -91,6 +93,7 @@ let main op path =
         | OpShowConfig -> show_config c path
         | OpSessionChanged -> session_changed c
         | OpConfigUnsaved -> config_unsaved c None
+        | OpReferencePathExists -> reference_path_exists c path
         end
     | Error e -> Error e |> Lwt.return
     in
@@ -128,7 +131,7 @@ let () =
         with Failure msg -> let () = print_endline msg in exit 1
     in
     match op, path_list with
-    | OpSetEditLevel, [] ->
+    | OpSetEditLevel, [] | OpReferencePathExists, [] ->
         let () = print_endline "Must specify config path" in exit 1
     | _, _ ->
         let result = Lwt_main.run (main op path_list) in exit result

--- a/src/vyconf_cli_compat.ml
+++ b/src/vyconf_cli_compat.ml
@@ -11,6 +11,7 @@ type op_t =
     | OpSessionChanged
     | OpConfigUnsaved
     | OpReferencePathExists
+    | OpGetPathType
 
 let op_of_arg s =
     match s with
@@ -23,6 +24,7 @@ let op_of_arg s =
     | "sessionChanged" -> OpSessionChanged
     | "sessionUnsaved" -> OpConfigUnsaved
     | "validateTmplPath" -> OpReferencePathExists
+    | "getNodeType" -> OpGetPathType
     | _ -> failwith (Printf.sprintf "Unknown operation %s" s)
 
 let in_cli_config_session () =
@@ -94,6 +96,7 @@ let main op path =
         | OpSessionChanged -> session_changed c
         | OpConfigUnsaved -> config_unsaved c None
         | OpReferencePathExists -> reference_path_exists c path
+        | OpGetPathType -> get_path_type c path
         end
     | Error e -> Error e |> Lwt.return
     in
@@ -131,7 +134,7 @@ let () =
         with Failure msg -> let () = print_endline msg in exit 1
     in
     match op, path_list with
-    | OpSetEditLevel, [] | OpReferencePathExists, [] ->
+    | OpSetEditLevel, [] | OpReferencePathExists, [] | OpGetPathType, [] ->
         let () = print_endline "Must specify config path" in exit 1
     | _, _ ->
         let result = Lwt_main.run (main op path_list) in exit result

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -237,3 +237,11 @@ let reference_path_exists client path =
     | Success -> Lwt.return (Ok "")
     | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let get_path_type client path =
+    let req = Get_path_type {path=path; legacy_format=true;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> unwrap resp.output |> Lwt.return
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -245,3 +245,12 @@ let get_path_type client path =
     | Success -> unwrap resp.output |> Lwt.return
     | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let get_completion_env client path =
+    let req = Get_completion_env {path=path; legacy_format=true;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> unwrap resp.output |> Lwt.return
+    (* legacy getCompletionEnv is silent on error *)
+    | Fail -> Error "" |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -229,3 +229,11 @@ let config_unsaved client file =
     | Success -> Lwt.return (Ok "")
     | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let reference_path_exists client path =
+    let req = Reference_path_exists {path=path;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> Lwt.return (Ok "")
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -49,3 +49,5 @@ val get_edit_level : t -> (string, string) result Lwt.t
 val edit_level_root : t -> (string, string) result Lwt.t
 
 val config_unsaved : t -> string option -> (string, string) result Lwt.t
+
+val reference_path_exists : t -> string list -> (string, string) result Lwt.t

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -51,3 +51,5 @@ val edit_level_root : t -> (string, string) result Lwt.t
 val config_unsaved : t -> string option -> (string, string) result Lwt.t
 
 val reference_path_exists : t -> string list -> (string, string) result Lwt.t
+
+val get_path_type : t -> string list -> (string, string) result Lwt.t

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -53,3 +53,5 @@ val config_unsaved : t -> string option -> (string, string) result Lwt.t
 val reference_path_exists : t -> string list -> (string, string) result Lwt.t
 
 val get_path_type : t -> string list -> (string, string) result Lwt.t
+
+val get_completion_env : t -> string list -> (string, string) result Lwt.t

--- a/src/vyconf_pbt.ml
+++ b/src/vyconf_pbt.ml
@@ -192,6 +192,11 @@ type request_get_path_type = {
   legacy_format : bool;
 }
 
+type request_get_completion_env = {
+  path : string list;
+  legacy_format : bool;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -233,6 +238,7 @@ type request =
   | Config_unsaved of request_config_unsaved
   | Reference_path_exists of request_reference_path_exists
   | Get_path_type of request_get_path_type
+  | Get_completion_env of request_get_completion_env
 
 type request_envelope = {
   token : string option;
@@ -546,6 +552,14 @@ let rec default_request_get_path_type
   ?path:((path:string list) = [])
   ?legacy_format:((legacy_format:bool) = false)
   () : request_get_path_type  = {
+  path;
+  legacy_format;
+}
+
+let rec default_request_get_completion_env 
+  ?path:((path:string list) = [])
+  ?legacy_format:((legacy_format:bool) = false)
+  () : request_get_completion_env  = {
   path;
   legacy_format;
 }
@@ -930,6 +944,16 @@ let default_request_get_path_type_mutable () : request_get_path_type_mutable = {
   legacy_format = false;
 }
 
+type request_get_completion_env_mutable = {
+  mutable path : string list;
+  mutable legacy_format : bool;
+}
+
+let default_request_get_completion_env_mutable () : request_get_completion_env_mutable = {
+  path = [];
+  legacy_format = false;
+}
+
 type request_envelope_mutable = {
   mutable token : string option;
   mutable request : request;
@@ -1238,6 +1262,13 @@ let rec pp_request_get_path_type fmt (v:request_get_path_type) =
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
 
+let rec pp_request_get_completion_env fmt (v:request_get_completion_env) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "path" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.path;
+    Pbrt.Pp.pp_record_field ~first:false "legacy_format" Pbrt.Pp.pp_bool fmt v.legacy_format;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
 let rec pp_request fmt (v:request) =
   match v with
   | Prompt  -> Format.fprintf fmt "Prompt"
@@ -1280,6 +1311,7 @@ let rec pp_request fmt (v:request) =
   | Config_unsaved x -> Format.fprintf fmt "@[<hv2>Config_unsaved(@,%a)@]" pp_request_config_unsaved x
   | Reference_path_exists x -> Format.fprintf fmt "@[<hv2>Reference_path_exists(@,%a)@]" pp_request_reference_path_exists x
   | Get_path_type x -> Format.fprintf fmt "@[<hv2>Get_path_type(@,%a)@]" pp_request_get_path_type x
+  | Get_completion_env x -> Format.fprintf fmt "@[<hv2>Get_completion_env(@,%a)@]" pp_request_get_completion_env x
 
 let rec pp_request_envelope fmt (v:request_envelope) = 
   let pp_i fmt () =
@@ -1732,6 +1764,15 @@ let rec encode_pb_request_get_path_type (v:request_get_path_type) encoder =
   Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
   ()
 
+let rec encode_pb_request_get_completion_env (v:request_get_completion_env) encoder = 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ) v.path encoder;
+  Pbrt.Encoder.bool v.legacy_format encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  ()
+
 let rec encode_pb_request (v:request) encoder = 
   begin match v with
   | Prompt ->
@@ -1854,6 +1895,9 @@ let rec encode_pb_request (v:request) encoder =
   | Get_path_type x ->
     Pbrt.Encoder.nested encode_pb_request_get_path_type x encoder;
     Pbrt.Encoder.key 40 Pbrt.Bytes encoder; 
+  | Get_completion_env x ->
+    Pbrt.Encoder.nested encode_pb_request_get_completion_env x encoder;
+    Pbrt.Encoder.key 41 Pbrt.Bytes encoder; 
   end
 
 let rec encode_pb_request_envelope (v:request_envelope) encoder = 
@@ -2840,6 +2884,33 @@ let rec decode_pb_request_get_path_type d =
     legacy_format = v.legacy_format;
   } : request_get_path_type)
 
+let rec decode_pb_request_get_completion_env d =
+  let v = default_request_get_completion_env_mutable () in
+  let continue__= ref true in
+  let legacy_format_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.path <- List.rev v.path;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.path <- (Pbrt.Decoder.string d) :: v.path;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_get_completion_env), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.legacy_format <- Pbrt.Decoder.bool d; legacy_format_is_set := true;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_get_completion_env), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !legacy_format_is_set then Pbrt.Decoder.missing_field "legacy_format" end;
+  ({
+    path = v.path;
+    legacy_format = v.legacy_format;
+  } : request_get_completion_env)
+
 let rec decode_pb_request d = 
   let rec loop () = 
     let ret:request = match Pbrt.Decoder.key d with
@@ -2893,6 +2964,7 @@ let rec decode_pb_request d =
       | Some (38, _) -> (Config_unsaved (decode_pb_request_config_unsaved (Pbrt.Decoder.nested d)) : request) 
       | Some (39, _) -> (Reference_path_exists (decode_pb_request_reference_path_exists (Pbrt.Decoder.nested d)) : request) 
       | Some (40, _) -> (Get_path_type (decode_pb_request_get_path_type (Pbrt.Decoder.nested d)) : request) 
+      | Some (41, _) -> (Get_completion_env (decode_pb_request_get_completion_env (Pbrt.Decoder.nested d)) : request) 
       | Some (n, payload_kind) -> (
         Pbrt.Decoder.skip d payload_kind; 
         loop () 

--- a/src/vyconf_pbt.ml
+++ b/src/vyconf_pbt.ml
@@ -187,6 +187,11 @@ type request_reference_path_exists = {
   path : string list;
 }
 
+type request_get_path_type = {
+  path : string list;
+  legacy_format : bool;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -227,6 +232,7 @@ type request =
   | Edit_level_root of request_edit_level_root
   | Config_unsaved of request_config_unsaved
   | Reference_path_exists of request_reference_path_exists
+  | Get_path_type of request_get_path_type
 
 type request_envelope = {
   token : string option;
@@ -534,6 +540,14 @@ let rec default_request_reference_path_exists
   ?path:((path:string list) = [])
   () : request_reference_path_exists  = {
   path;
+}
+
+let rec default_request_get_path_type 
+  ?path:((path:string list) = [])
+  ?legacy_format:((legacy_format:bool) = false)
+  () : request_get_path_type  = {
+  path;
+  legacy_format;
 }
 
 let rec default_request (): request = Prompt
@@ -906,6 +920,16 @@ let default_request_reference_path_exists_mutable () : request_reference_path_ex
   path = [];
 }
 
+type request_get_path_type_mutable = {
+  mutable path : string list;
+  mutable legacy_format : bool;
+}
+
+let default_request_get_path_type_mutable () : request_get_path_type_mutable = {
+  path = [];
+  legacy_format = false;
+}
+
 type request_envelope_mutable = {
   mutable token : string option;
   mutable request : request;
@@ -1207,6 +1231,13 @@ let rec pp_request_reference_path_exists fmt (v:request_reference_path_exists) =
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
 
+let rec pp_request_get_path_type fmt (v:request_get_path_type) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "path" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.path;
+    Pbrt.Pp.pp_record_field ~first:false "legacy_format" Pbrt.Pp.pp_bool fmt v.legacy_format;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
 let rec pp_request fmt (v:request) =
   match v with
   | Prompt  -> Format.fprintf fmt "Prompt"
@@ -1248,6 +1279,7 @@ let rec pp_request fmt (v:request) =
   | Edit_level_root x -> Format.fprintf fmt "@[<hv2>Edit_level_root(@,%a)@]" pp_request_edit_level_root x
   | Config_unsaved x -> Format.fprintf fmt "@[<hv2>Config_unsaved(@,%a)@]" pp_request_config_unsaved x
   | Reference_path_exists x -> Format.fprintf fmt "@[<hv2>Reference_path_exists(@,%a)@]" pp_request_reference_path_exists x
+  | Get_path_type x -> Format.fprintf fmt "@[<hv2>Get_path_type(@,%a)@]" pp_request_get_path_type x
 
 let rec pp_request_envelope fmt (v:request_envelope) = 
   let pp_i fmt () =
@@ -1691,6 +1723,15 @@ let rec encode_pb_request_reference_path_exists (v:request_reference_path_exists
   ) v.path encoder;
   ()
 
+let rec encode_pb_request_get_path_type (v:request_get_path_type) encoder = 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ) v.path encoder;
+  Pbrt.Encoder.bool v.legacy_format encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  ()
+
 let rec encode_pb_request (v:request) encoder = 
   begin match v with
   | Prompt ->
@@ -1810,6 +1851,9 @@ let rec encode_pb_request (v:request) encoder =
   | Reference_path_exists x ->
     Pbrt.Encoder.nested encode_pb_request_reference_path_exists x encoder;
     Pbrt.Encoder.key 39 Pbrt.Bytes encoder; 
+  | Get_path_type x ->
+    Pbrt.Encoder.nested encode_pb_request_get_path_type x encoder;
+    Pbrt.Encoder.key 40 Pbrt.Bytes encoder; 
   end
 
 let rec encode_pb_request_envelope (v:request_envelope) encoder = 
@@ -2769,6 +2813,33 @@ let rec decode_pb_request_reference_path_exists d =
     path = v.path;
   } : request_reference_path_exists)
 
+let rec decode_pb_request_get_path_type d =
+  let v = default_request_get_path_type_mutable () in
+  let continue__= ref true in
+  let legacy_format_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.path <- List.rev v.path;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.path <- (Pbrt.Decoder.string d) :: v.path;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_get_path_type), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.legacy_format <- Pbrt.Decoder.bool d; legacy_format_is_set := true;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_get_path_type), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !legacy_format_is_set then Pbrt.Decoder.missing_field "legacy_format" end;
+  ({
+    path = v.path;
+    legacy_format = v.legacy_format;
+  } : request_get_path_type)
+
 let rec decode_pb_request d = 
   let rec loop () = 
     let ret:request = match Pbrt.Decoder.key d with
@@ -2821,6 +2892,7 @@ let rec decode_pb_request d =
       | Some (37, _) -> (Edit_level_root (decode_pb_request_edit_level_root (Pbrt.Decoder.nested d)) : request) 
       | Some (38, _) -> (Config_unsaved (decode_pb_request_config_unsaved (Pbrt.Decoder.nested d)) : request) 
       | Some (39, _) -> (Reference_path_exists (decode_pb_request_reference_path_exists (Pbrt.Decoder.nested d)) : request) 
+      | Some (40, _) -> (Get_path_type (decode_pb_request_get_path_type (Pbrt.Decoder.nested d)) : request) 
       | Some (n, payload_kind) -> (
         Pbrt.Decoder.skip d payload_kind; 
         loop () 

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -199,6 +199,11 @@ type request_get_path_type = {
   legacy_format : bool;
 }
 
+type request_get_completion_env = {
+  path : string list;
+  legacy_format : bool;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -240,6 +245,7 @@ type request =
   | Config_unsaved of request_config_unsaved
   | Reference_path_exists of request_reference_path_exists
   | Get_path_type of request_get_path_type
+  | Get_completion_env of request_get_completion_env
 
 type request_envelope = {
   token : string option;
@@ -535,6 +541,13 @@ val default_request_get_path_type :
   request_get_path_type
 (** [default_request_get_path_type ()] is the default value for type [request_get_path_type] *)
 
+val default_request_get_completion_env : 
+  ?path:string list ->
+  ?legacy_format:bool ->
+  unit ->
+  request_get_completion_env
+(** [default_request_get_completion_env ()] is the default value for type [request_get_completion_env] *)
+
 val default_request : unit -> request
 (** [default_request ()] is the default value for type [request] *)
 
@@ -686,6 +699,9 @@ val pp_request_reference_path_exists : Format.formatter -> request_reference_pat
 val pp_request_get_path_type : Format.formatter -> request_get_path_type -> unit 
 (** [pp_request_get_path_type v] formats v *)
 
+val pp_request_get_completion_env : Format.formatter -> request_get_completion_env -> unit 
+(** [pp_request_get_completion_env v] formats v *)
+
 val pp_request : Format.formatter -> request -> unit 
 (** [pp_request v] formats v *)
 
@@ -827,6 +843,9 @@ val encode_pb_request_reference_path_exists : request_reference_path_exists -> P
 val encode_pb_request_get_path_type : request_get_path_type -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_get_path_type v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_get_completion_env : request_get_completion_env -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_get_completion_env v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request v encoder] encodes [v] with the given [encoder] *)
 
@@ -967,6 +986,9 @@ val decode_pb_request_reference_path_exists : Pbrt.Decoder.t -> request_referenc
 
 val decode_pb_request_get_path_type : Pbrt.Decoder.t -> request_get_path_type
 (** [decode_pb_request_get_path_type decoder] decodes a [request_get_path_type] binary value from [decoder] *)
+
+val decode_pb_request_get_completion_env : Pbrt.Decoder.t -> request_get_completion_env
+(** [decode_pb_request_get_completion_env decoder] decodes a [request_get_completion_env] binary value from [decoder] *)
 
 val decode_pb_request : Pbrt.Decoder.t -> request
 (** [decode_pb_request decoder] decodes a [request] binary value from [decoder] *)

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -194,6 +194,11 @@ type request_reference_path_exists = {
   path : string list;
 }
 
+type request_get_path_type = {
+  path : string list;
+  legacy_format : bool;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -234,6 +239,7 @@ type request =
   | Edit_level_root of request_edit_level_root
   | Config_unsaved of request_config_unsaved
   | Reference_path_exists of request_reference_path_exists
+  | Get_path_type of request_get_path_type
 
 type request_envelope = {
   token : string option;
@@ -522,6 +528,13 @@ val default_request_reference_path_exists :
   request_reference_path_exists
 (** [default_request_reference_path_exists ()] is the default value for type [request_reference_path_exists] *)
 
+val default_request_get_path_type : 
+  ?path:string list ->
+  ?legacy_format:bool ->
+  unit ->
+  request_get_path_type
+(** [default_request_get_path_type ()] is the default value for type [request_get_path_type] *)
+
 val default_request : unit -> request
 (** [default_request ()] is the default value for type [request] *)
 
@@ -670,6 +683,9 @@ val pp_request_config_unsaved : Format.formatter -> request_config_unsaved -> un
 val pp_request_reference_path_exists : Format.formatter -> request_reference_path_exists -> unit 
 (** [pp_request_reference_path_exists v] formats v *)
 
+val pp_request_get_path_type : Format.formatter -> request_get_path_type -> unit 
+(** [pp_request_get_path_type v] formats v *)
+
 val pp_request : Format.formatter -> request -> unit 
 (** [pp_request v] formats v *)
 
@@ -808,6 +824,9 @@ val encode_pb_request_config_unsaved : request_config_unsaved -> Pbrt.Encoder.t 
 val encode_pb_request_reference_path_exists : request_reference_path_exists -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_reference_path_exists v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_get_path_type : request_get_path_type -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_get_path_type v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request v encoder] encodes [v] with the given [encoder] *)
 
@@ -945,6 +964,9 @@ val decode_pb_request_config_unsaved : Pbrt.Decoder.t -> request_config_unsaved
 
 val decode_pb_request_reference_path_exists : Pbrt.Decoder.t -> request_reference_path_exists
 (** [decode_pb_request_reference_path_exists decoder] decodes a [request_reference_path_exists] binary value from [decoder] *)
+
+val decode_pb_request_get_path_type : Pbrt.Decoder.t -> request_get_path_type
+(** [decode_pb_request_get_path_type decoder] decodes a [request_get_path_type] binary value from [decoder] *)
 
 val decode_pb_request : Pbrt.Decoder.t -> request
 (** [decode_pb_request decoder] decodes a [request] binary value from [decoder] *)

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -190,6 +190,10 @@ type request_config_unsaved = {
   file : string option;
 }
 
+type request_reference_path_exists = {
+  path : string list;
+}
+
 type request =
   | Prompt
   | Setup_session of request_setup_session
@@ -229,6 +233,7 @@ type request =
   | Get_edit_level of request_get_edit_level
   | Edit_level_root of request_edit_level_root
   | Config_unsaved of request_config_unsaved
+  | Reference_path_exists of request_reference_path_exists
 
 type request_envelope = {
   token : string option;
@@ -511,6 +516,12 @@ val default_request_config_unsaved :
   request_config_unsaved
 (** [default_request_config_unsaved ()] is the default value for type [request_config_unsaved] *)
 
+val default_request_reference_path_exists : 
+  ?path:string list ->
+  unit ->
+  request_reference_path_exists
+(** [default_request_reference_path_exists ()] is the default value for type [request_reference_path_exists] *)
+
 val default_request : unit -> request
 (** [default_request ()] is the default value for type [request] *)
 
@@ -656,6 +667,9 @@ val pp_request_edit_level_root : Format.formatter -> request_edit_level_root -> 
 val pp_request_config_unsaved : Format.formatter -> request_config_unsaved -> unit 
 (** [pp_request_config_unsaved v] formats v *)
 
+val pp_request_reference_path_exists : Format.formatter -> request_reference_path_exists -> unit 
+(** [pp_request_reference_path_exists v] formats v *)
+
 val pp_request : Format.formatter -> request -> unit 
 (** [pp_request v] formats v *)
 
@@ -791,6 +805,9 @@ val encode_pb_request_edit_level_root : request_edit_level_root -> Pbrt.Encoder.
 val encode_pb_request_config_unsaved : request_config_unsaved -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_config_unsaved v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_reference_path_exists : request_reference_path_exists -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_reference_path_exists v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request v encoder] encodes [v] with the given [encoder] *)
 
@@ -925,6 +942,9 @@ val decode_pb_request_edit_level_root : Pbrt.Decoder.t -> request_edit_level_roo
 
 val decode_pb_request_config_unsaved : Pbrt.Decoder.t -> request_config_unsaved
 (** [decode_pb_request_config_unsaved decoder] decodes a [request_config_unsaved] binary value from [decoder] *)
+
+val decode_pb_request_reference_path_exists : Pbrt.Decoder.t -> request_reference_path_exists
+(** [decode_pb_request_reference_path_exists decoder] decodes a [request_reference_path_exists] binary value from [decoder] *)
 
 val decode_pb_request : Pbrt.Decoder.t -> request
 (** [decode_pb_request decoder] decodes a [request] binary value from [decoder] *)

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -417,6 +417,12 @@ let config_unsaved world token (req: request_config_unsaved) =
     then response_tmpl
     else {response_tmpl with status=Fail}
 
+let reference_path_exists world token (req: request_reference_path_exists) =
+    let path = req.path in
+    if Session.reference_path_exists world (find_session token) path
+    then response_tmpl
+    else {response_tmpl with status=Fail}
+
 let send_response oc resp =
     let enc = Pbrt.Encoder.create () in
     let%lwt () = encode_pb_response resp enc |> return in
@@ -474,6 +480,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Get_edit_level r -> get_edit_level world t r
                     | Some t, Edit_level_root r -> edit_level_root world t r
                     | Some t, Config_unsaved r -> config_unsaved world t r
+                    | Some t, Reference_path_exists r -> reference_path_exists world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -433,6 +433,17 @@ let get_path_type world token (req: request_get_path_type) =
     with Session.Session_error msg ->
         {response_tmpl with status=Fail; error=(Some msg)}
 
+let get_completion_env world token (req: request_get_completion_env) =
+    let s = find_session token in
+    try
+        let node_type =
+            Session.get_completion_env
+            ~legacy_format:req.legacy_format world s req.path
+        in
+        {response_tmpl with output=(Some node_type)}
+    with Session.Session_error msg ->
+        {response_tmpl with status=Fail; error=(Some msg)}
+
 let send_response oc resp =
     let enc = Pbrt.Encoder.create () in
     let%lwt () = encode_pb_response resp enc |> return in
@@ -492,6 +503,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Config_unsaved r -> config_unsaved world t r
                     | Some t, Reference_path_exists r -> reference_path_exists world t r
                     | Some t, Get_path_type r -> get_path_type world t r
+                    | Some t, Get_completion_env r -> get_completion_env world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -423,6 +423,16 @@ let reference_path_exists world token (req: request_reference_path_exists) =
     then response_tmpl
     else {response_tmpl with status=Fail}
 
+let get_path_type world token (req: request_get_path_type) =
+    let s = find_session token in
+    try
+        let node_type =
+            Session.get_path_type ~legacy_format:req.legacy_format world s req.path
+        in
+        {response_tmpl with output=(Some node_type)}
+    with Session.Session_error msg ->
+        {response_tmpl with status=Fail; error=(Some msg)}
+
 let send_response oc resp =
     let enc = Pbrt.Encoder.create () in
     let%lwt () = encode_pb_response resp enc |> return in
@@ -481,6 +491,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Edit_level_root r -> edit_level_root world t r
                     | Some t, Config_unsaved r -> config_unsaved world t r
                     | Some t, Reference_path_exists r -> reference_path_exists world t r
+                    | Some t, Get_path_type r -> get_path_type world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add requests to return the analogues of cli-shell-api functions relating to completion data of paths.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Other (please describe): integration of vyconf with shell internal functions and completion

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/59

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
