### PR TITLE
T8313: add vyconf support for copy/rename

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -69,16 +69,14 @@ message Request {
     optional int32 dummy = 1;
   }
 
-  message Rename {
-    repeated string edit_level = 1;
-    required string source = 2;
-    required string destination = 3;
+  message Copy {
+    repeated string source = 1;
+    repeated string destination = 2;
   }
 
-  message Copy {
-    repeated string edit_level = 1;
-    required string source = 2;
-    required string destination = 3;
+  message Rename {
+    repeated string source = 1;
+    repeated string destination = 2;
   }
 
   message Comment {

--- a/src/session.ml
+++ b/src/session.ml
@@ -267,6 +267,53 @@ let aux_delete w s path name tagval =
 let discard _w s =
     { s with changeset = []; }
 
+let copy w s p1 p2 =
+    if Vyos1x.Util.is_empty p1
+    then raise (Session_error "Cannot copy an empty path")
+    else
+    if Vyos1x.Util.is_empty p2
+    then raise (Session_error "Cannot copy to an empty path")
+    else
+    let p1_total = s.edit_level @ p1 in
+    let p2_total = s.edit_level @ p2 in
+    let ct = get_proposed_config w s in
+    if not ((VT.exists[@alert "-exn"]) ct p1_total)
+    then
+    let p1_str = Vyos1x.Util.string_of_list p1_total in
+    let out = Printf.sprintf "Configuration path \"%s\" does not exist" p1_str in
+    raise (Session_error out)
+    else
+    let _ = validate w s p2_total in
+    let ct' = (VT.copy[@alert "-exn"]) ct p1_total p2_total in
+    let changeset' = get_changeset w s ct ct' in
+    { s with changeset = changeset' @ s.changeset }
+
+let rename w s p1 p2 =
+    if Vyos1x.Util.is_empty p1
+    then raise (Session_error "Cannot rename an empty path")
+    else
+    let p2_last =
+      match Vyos1x.Util.get_last p2 with
+      | None -> raise (Session_error "Cannot rename to an empty value")
+      | Some v -> v
+    in
+    if (Vyos1x.Util.drop_last p1) <> (Vyos1x.Util.drop_last p2)
+    then raise (Session_error "Cannot rename a node: paths are inconsistent")
+    else
+    let p1_total = s.edit_level @ p1 in
+    let p2_total = s.edit_level @ p2 in
+    let ct = get_proposed_config w s in
+    if not ((VT.exists[@alert "-exn"]) ct p1_total)
+    then
+    let p1_str = Vyos1x.Util.string_of_list p1_total in
+    let out = Printf.sprintf "Configuration path \"%s\" does not exist" p1_str in
+    raise (Session_error out)
+    else
+    let _ = validate w s p2_total in
+    let ct' = (VT.rename[@alert "-exn"]) ct p1_total p2_last in
+    let changeset' = get_changeset w s ct ct' in
+    { s with changeset = changeset' @ s.changeset }
+
 let edit_env_str s =
     (* To maintain consistency with classic CLI, we return env variable for
        PS1 on changes to edit level.

--- a/src/session.ml
+++ b/src/session.ml
@@ -405,8 +405,9 @@ let get_completion_env ?(legacy_format=false) w s path =
         | h :: tl -> (h, tl)
     in
     let config = get_proposed_config w s in
+    let path_total = s.edit_level @ path in
     let res =
-        Vyos1x.Completion.get_completion_env_str ~legacy_format w.reference_tree config op path
+        Vyos1x.Completion.get_completion_env_str ~legacy_format w.reference_tree config op path_total
     in
     match res with
     | Ok env -> env

--- a/src/session.mli
+++ b/src/session.mli
@@ -100,3 +100,7 @@ val reference_path_exists : world -> session_data -> string list -> bool
 val get_path_type : ?legacy_format:bool -> world -> session_data -> string list -> string
 
 val get_completion_env : ?legacy_format:bool -> world -> session_data -> string list -> string
+
+val copy : world -> session_data -> string list -> string list -> session_data
+
+val rename : world -> session_data -> string list -> string list -> session_data

--- a/src/vyconf_cli.ml
+++ b/src/vyconf_cli.ml
@@ -5,12 +5,16 @@ type op_t =
     | OpSet
     | OpDelete
     | OpDiscard
+    | OpCopy
+    | OpRename
 
 let op_of_string s =
     match s with
     | "vy_set" -> OpSet
     | "vy_delete" -> OpDelete
     | "vy_discard" -> OpDiscard
+    | "vy_copy" -> OpCopy
+    | "vy_rename" -> OpRename
     | _ -> failwith (Printf.sprintf "Unknown operation %s" s)
 
 let config_format_of_string s =
@@ -76,6 +80,8 @@ let main op path =
         | OpSet -> set c path
         | OpDelete -> delete c path
         | OpDiscard -> discard c
+        | OpCopy -> copy c path
+        | OpRename -> rename c path
         end
     | Error e -> Error e |> Lwt.return
     in
@@ -109,5 +115,7 @@ let () =
     match op, path_list with
     | OpSet, [] | OpDelete, [] ->
         let () = print_endline "Must specify config path" in exit 1
+    | OpCopy, [] | OpRename, [] ->
+        let () = print_endline "Copy and rename operations require configuration paths" in exit 1
     | _, _ ->
         let result = Lwt_main.run (main op path_list) in exit result

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -254,3 +254,25 @@ let get_completion_env client path =
     (* legacy getCompletionEnv is silent on error *)
     | Fail -> Error "" |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let copy client path =
+    let path_arr = Array.of_list path in
+    let path1 = Array.to_list (Array.sub path_arr 0 2) in
+    let path2 = Array.to_list (Array.sub path_arr 3 2) in
+    let req = Copy {source=path1; destination=path2;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> Lwt.return (Ok "")
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let rename client path =
+    let path_arr = Array.of_list path in
+    let path1 = Array.to_list (Array.sub path_arr 0 2) in
+    let path2 = Array.to_list (Array.sub path_arr 3 2) in
+    let req = Rename {source=path1; destination=path2;} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> Lwt.return (Ok "")
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -55,3 +55,7 @@ val reference_path_exists : t -> string list -> (string, string) result Lwt.t
 val get_path_type : t -> string list -> (string, string) result Lwt.t
 
 val get_completion_env : t -> string list -> (string, string) result Lwt.t
+
+val copy : t -> string list -> (string, string) result Lwt.t
+
+val rename : t -> string list -> (string, string) result Lwt.t

--- a/src/vyconf_pbt.ml
+++ b/src/vyconf_pbt.ml
@@ -67,16 +67,14 @@ type request_session_changed = {
   dummy : int32 option;
 }
 
-type request_rename = {
-  edit_level : string list;
-  source : string;
-  destination : string;
+type request_copy = {
+  source : string list;
+  destination : string list;
 }
 
-type request_copy = {
-  edit_level : string list;
-  source : string;
-  destination : string;
+type request_rename = {
+  source : string list;
+  destination : string list;
 }
 
 type request_comment = {
@@ -360,22 +358,18 @@ let rec default_request_session_changed
   dummy;
 }
 
-let rec default_request_rename 
-  ?edit_level:((edit_level:string list) = [])
-  ?source:((source:string) = "")
-  ?destination:((destination:string) = "")
-  () : request_rename  = {
-  edit_level;
+let rec default_request_copy 
+  ?source:((source:string list) = [])
+  ?destination:((destination:string list) = [])
+  () : request_copy  = {
   source;
   destination;
 }
 
-let rec default_request_copy 
-  ?edit_level:((edit_level:string list) = [])
-  ?source:((source:string) = "")
-  ?destination:((destination:string) = "")
-  () : request_copy  = {
-  edit_level;
+let rec default_request_rename 
+  ?source:((source:string list) = [])
+  ?destination:((destination:string list) = [])
+  () : request_rename  = {
   source;
   destination;
 }
@@ -702,28 +696,24 @@ let default_request_session_changed_mutable () : request_session_changed_mutable
   dummy = None;
 }
 
-type request_rename_mutable = {
-  mutable edit_level : string list;
-  mutable source : string;
-  mutable destination : string;
-}
-
-let default_request_rename_mutable () : request_rename_mutable = {
-  edit_level = [];
-  source = "";
-  destination = "";
-}
-
 type request_copy_mutable = {
-  mutable edit_level : string list;
-  mutable source : string;
-  mutable destination : string;
+  mutable source : string list;
+  mutable destination : string list;
 }
 
 let default_request_copy_mutable () : request_copy_mutable = {
-  edit_level = [];
-  source = "";
-  destination = "";
+  source = [];
+  destination = [];
+}
+
+type request_rename_mutable = {
+  mutable source : string list;
+  mutable destination : string list;
+}
+
+let default_request_rename_mutable () : request_rename_mutable = {
+  source = [];
+  destination = [];
 }
 
 type request_comment_mutable = {
@@ -1079,19 +1069,17 @@ let rec pp_request_session_changed fmt (v:request_session_changed) =
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
 
-let rec pp_request_rename fmt (v:request_rename) = 
+let rec pp_request_copy fmt (v:request_copy) = 
   let pp_i fmt () =
-    Pbrt.Pp.pp_record_field ~first:true "edit_level" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.edit_level;
-    Pbrt.Pp.pp_record_field ~first:false "source" Pbrt.Pp.pp_string fmt v.source;
-    Pbrt.Pp.pp_record_field ~first:false "destination" Pbrt.Pp.pp_string fmt v.destination;
+    Pbrt.Pp.pp_record_field ~first:true "source" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.source;
+    Pbrt.Pp.pp_record_field ~first:false "destination" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.destination;
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
 
-let rec pp_request_copy fmt (v:request_copy) = 
+let rec pp_request_rename fmt (v:request_rename) = 
   let pp_i fmt () =
-    Pbrt.Pp.pp_record_field ~first:true "edit_level" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.edit_level;
-    Pbrt.Pp.pp_record_field ~first:false "source" Pbrt.Pp.pp_string fmt v.source;
-    Pbrt.Pp.pp_record_field ~first:false "destination" Pbrt.Pp.pp_string fmt v.destination;
+    Pbrt.Pp.pp_record_field ~first:true "source" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.source;
+    Pbrt.Pp.pp_record_field ~first:false "destination" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.destination;
   in
   Pbrt.Pp.pp_brk pp_i fmt ()
 
@@ -1495,26 +1483,26 @@ let rec encode_pb_request_session_changed (v:request_session_changed) encoder =
   end;
   ()
 
-let rec encode_pb_request_rename (v:request_rename) encoder = 
-  Pbrt.List_util.rev_iter_with (fun x encoder -> 
-    Pbrt.Encoder.string x encoder;
-    Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
-  ) v.edit_level encoder;
-  Pbrt.Encoder.string v.source encoder;
-  Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
-  Pbrt.Encoder.string v.destination encoder;
-  Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
-  ()
-
 let rec encode_pb_request_copy (v:request_copy) encoder = 
   Pbrt.List_util.rev_iter_with (fun x encoder -> 
     Pbrt.Encoder.string x encoder;
     Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
-  ) v.edit_level encoder;
-  Pbrt.Encoder.string v.source encoder;
-  Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
-  Pbrt.Encoder.string v.destination encoder;
-  Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  ) v.source encoder;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  ) v.destination encoder;
+  ()
+
+let rec encode_pb_request_rename (v:request_rename) encoder = 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ) v.source encoder;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  ) v.destination encoder;
   ()
 
 let rec encode_pb_request_comment (v:request_comment) encoder = 
@@ -2252,75 +2240,57 @@ let rec decode_pb_request_session_changed d =
     dummy = v.dummy;
   } : request_session_changed)
 
-let rec decode_pb_request_rename d =
-  let v = default_request_rename_mutable () in
-  let continue__= ref true in
-  let destination_is_set = ref false in
-  let source_is_set = ref false in
-  while !continue__ do
-    match Pbrt.Decoder.key d with
-    | None -> (
-      v.edit_level <- List.rev v.edit_level;
-    ); continue__ := false
-    | Some (1, Pbrt.Bytes) -> begin
-      v.edit_level <- (Pbrt.Decoder.string d) :: v.edit_level;
-    end
-    | Some (1, pk) -> 
-      Pbrt.Decoder.unexpected_payload "Message(request_rename), field(1)" pk
-    | Some (2, Pbrt.Bytes) -> begin
-      v.source <- Pbrt.Decoder.string d; source_is_set := true;
-    end
-    | Some (2, pk) -> 
-      Pbrt.Decoder.unexpected_payload "Message(request_rename), field(2)" pk
-    | Some (3, Pbrt.Bytes) -> begin
-      v.destination <- Pbrt.Decoder.string d; destination_is_set := true;
-    end
-    | Some (3, pk) -> 
-      Pbrt.Decoder.unexpected_payload "Message(request_rename), field(3)" pk
-    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
-  done;
-  begin if not !destination_is_set then Pbrt.Decoder.missing_field "destination" end;
-  begin if not !source_is_set then Pbrt.Decoder.missing_field "source" end;
-  ({
-    edit_level = v.edit_level;
-    source = v.source;
-    destination = v.destination;
-  } : request_rename)
-
 let rec decode_pb_request_copy d =
   let v = default_request_copy_mutable () in
   let continue__= ref true in
-  let destination_is_set = ref false in
-  let source_is_set = ref false in
   while !continue__ do
     match Pbrt.Decoder.key d with
     | None -> (
-      v.edit_level <- List.rev v.edit_level;
+      v.destination <- List.rev v.destination;
+      v.source <- List.rev v.source;
     ); continue__ := false
     | Some (1, Pbrt.Bytes) -> begin
-      v.edit_level <- (Pbrt.Decoder.string d) :: v.edit_level;
+      v.source <- (Pbrt.Decoder.string d) :: v.source;
     end
     | Some (1, pk) -> 
       Pbrt.Decoder.unexpected_payload "Message(request_copy), field(1)" pk
     | Some (2, Pbrt.Bytes) -> begin
-      v.source <- Pbrt.Decoder.string d; source_is_set := true;
+      v.destination <- (Pbrt.Decoder.string d) :: v.destination;
     end
     | Some (2, pk) -> 
       Pbrt.Decoder.unexpected_payload "Message(request_copy), field(2)" pk
-    | Some (3, Pbrt.Bytes) -> begin
-      v.destination <- Pbrt.Decoder.string d; destination_is_set := true;
-    end
-    | Some (3, pk) -> 
-      Pbrt.Decoder.unexpected_payload "Message(request_copy), field(3)" pk
     | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
   done;
-  begin if not !destination_is_set then Pbrt.Decoder.missing_field "destination" end;
-  begin if not !source_is_set then Pbrt.Decoder.missing_field "source" end;
   ({
-    edit_level = v.edit_level;
     source = v.source;
     destination = v.destination;
   } : request_copy)
+
+let rec decode_pb_request_rename d =
+  let v = default_request_rename_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.destination <- List.rev v.destination;
+      v.source <- List.rev v.source;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.source <- (Pbrt.Decoder.string d) :: v.source;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_rename), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.destination <- (Pbrt.Decoder.string d) :: v.destination;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(request_rename), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    source = v.source;
+    destination = v.destination;
+  } : request_rename)
 
 let rec decode_pb_request_comment d =
   let v = default_request_comment_mutable () in

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -74,16 +74,14 @@ type request_session_changed = {
   dummy : int32 option;
 }
 
-type request_rename = {
-  edit_level : string list;
-  source : string;
-  destination : string;
+type request_copy = {
+  source : string list;
+  destination : string list;
 }
 
-type request_copy = {
-  edit_level : string list;
-  source : string;
-  destination : string;
+type request_rename = {
+  source : string list;
+  destination : string list;
 }
 
 type request_comment = {
@@ -364,21 +362,19 @@ val default_request_session_changed :
   request_session_changed
 (** [default_request_session_changed ()] is the default value for type [request_session_changed] *)
 
-val default_request_rename : 
-  ?edit_level:string list ->
-  ?source:string ->
-  ?destination:string ->
-  unit ->
-  request_rename
-(** [default_request_rename ()] is the default value for type [request_rename] *)
-
 val default_request_copy : 
-  ?edit_level:string list ->
-  ?source:string ->
-  ?destination:string ->
+  ?source:string list ->
+  ?destination:string list ->
   unit ->
   request_copy
 (** [default_request_copy ()] is the default value for type [request_copy] *)
+
+val default_request_rename : 
+  ?source:string list ->
+  ?destination:string list ->
+  unit ->
+  request_rename
+(** [default_request_rename ()] is the default value for type [request_rename] *)
 
 val default_request_comment : 
   ?path:string list ->
@@ -618,11 +614,11 @@ val pp_request_discard : Format.formatter -> request_discard -> unit
 val pp_request_session_changed : Format.formatter -> request_session_changed -> unit 
 (** [pp_request_session_changed v] formats v *)
 
-val pp_request_rename : Format.formatter -> request_rename -> unit 
-(** [pp_request_rename v] formats v *)
-
 val pp_request_copy : Format.formatter -> request_copy -> unit 
 (** [pp_request_copy v] formats v *)
+
+val pp_request_rename : Format.formatter -> request_rename -> unit 
+(** [pp_request_rename v] formats v *)
 
 val pp_request_comment : Format.formatter -> request_comment -> unit 
 (** [pp_request_comment v] formats v *)
@@ -762,11 +758,11 @@ val encode_pb_request_discard : request_discard -> Pbrt.Encoder.t -> unit
 val encode_pb_request_session_changed : request_session_changed -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_session_changed v encoder] encodes [v] with the given [encoder] *)
 
-val encode_pb_request_rename : request_rename -> Pbrt.Encoder.t -> unit
-(** [encode_pb_request_rename v encoder] encodes [v] with the given [encoder] *)
-
 val encode_pb_request_copy : request_copy -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_copy v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_request_rename : request_rename -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_rename v encoder] encodes [v] with the given [encoder] *)
 
 val encode_pb_request_comment : request_comment -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_comment v encoder] encodes [v] with the given [encoder] *)
@@ -906,11 +902,11 @@ val decode_pb_request_discard : Pbrt.Decoder.t -> request_discard
 val decode_pb_request_session_changed : Pbrt.Decoder.t -> request_session_changed
 (** [decode_pb_request_session_changed decoder] decodes a [request_session_changed] binary value from [decoder] *)
 
-val decode_pb_request_rename : Pbrt.Decoder.t -> request_rename
-(** [decode_pb_request_rename decoder] decodes a [request_rename] binary value from [decoder] *)
-
 val decode_pb_request_copy : Pbrt.Decoder.t -> request_copy
 (** [decode_pb_request_copy decoder] decodes a [request_copy] binary value from [decoder] *)
+
+val decode_pb_request_rename : Pbrt.Decoder.t -> request_rename
+(** [decode_pb_request_rename decoder] decodes a [request_rename] binary value from [decoder] *)
 
 val decode_pb_request_comment : Pbrt.Decoder.t -> request_comment
 (** [decode_pb_request_comment decoder] decodes a [request_comment] binary value from [decoder] *)

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -263,6 +263,22 @@ let discard world token (_req: request_discard) =
         response_tmpl
     with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
 
+let copy world token (req: request_copy) =
+    try
+        let session = Session.copy world (find_session token) req.source req.destination
+        in
+        Hashtbl.replace sessions token session;
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
+let rename world token (req: request_rename) =
+    try
+        let session = Session.rename world (find_session token) req.source req.destination
+        in
+        Hashtbl.replace sessions token session;
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
 let load world token (req: request_load) =
     try
         let session = Session.load world (find_session token) req.location req.cached
@@ -505,6 +521,8 @@ let rec handle_connection world ic oc () =
                     | Some t, Reference_path_exists r -> reference_path_exists world t r
                     | Some t, Get_path_type r -> get_path_type world t r
                     | Some t, Get_completion_env r -> get_completion_env world t r
+                    | Some t, Copy r -> copy world t r
+                    | Some t, Rename r -> rename world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Note that this will require https://github.com/vyos/vyos1x-config/pull/66
Add vyconf support for copy/rename.

Once supporting PRs are in place (vyos1x-config; vyatta-cfg; vyos-1x). The standard examples of copy/rename, as in:
https://blog.vyos.io/copying/renaming-node-comments-and-other-little-known-features-of-the-vyos-cli
will be supported by vyconf requests and vyconf-aware bash functions/completion.

Granted that this may be a lesser used feature, but it is a necessary (if simple) implementation in order to remove reliance on vyatta-cfg; moreover, it is another check of coverage by existing tools, and a check of missing features/bugs (e.g. T8312 in the related vyos1x-config PR).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Other (please describe): extend vyconf support for copy/rename

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/66
https://github.com/vyos/vyatta-cfg/pull/125
https://github.com/vyos/vyos-1x/pull/5011

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

As mentioned above, with all companion PRs in place, check copy/rename examples here;
https://blog.vyos.io/copying/renaming-node-comments-and-other-little-known-features-of-the-vyos-cli
with vyconf enabled.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
