### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Sibling to `vyos/vyos1x-config` (the OCaml library that owns the actual config-t
 
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced by `vyos/.github` reusable.
-- Default branch: `current`. Release-train branches: `current`, `circinus`, `sagitta`, `equuleus`.
+- Default branch: `rolling`. Release-train branches: `rolling`, `circinus`, `sagitta`, `equuleus`.
 - Mergify backports via `@Mergifyio backport <branch>`.
 - OCaml core repos (this, `vyos1x-config`, `vyos-utils`) follow MIT/LGPL upstream norms.
 


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)