### PR TITLE
ci: T8490: fix typos in comments and docs

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -36,7 +36,7 @@ under a single interface.
 The other problem, apart from unification, that we are aiming to solve is robustness
 and reliability. Many applications simply take any configuration and fail to start
 if it's incorrect, correctness verification is left up to the users. For an appliance
-it's preferrable when in case of user error the incorrect configuration is not applied
+it's preferable when in case of user error the incorrect configuration is not applied
 at all.
 
 The other problem is that configuration of individual applications may be correct,
@@ -44,7 +44,7 @@ but the overall appliance configuration may not, e.g. if the user set an applica
 to listen on specific address, but did not configure the network interface accordingly.
 
 A possible solution to this is to make configuration stateful and atomic. First a 
-proposed configuration is built, then it's commited, and if any stage fails, it's
+proposed configuration is built, then it's committed, and if any stage fails, it's
 rolled back to its previous state. This also simplifies accounting and allows to keep
 configuration revision history and rollback to previous revisions.
 

--- a/data/schemata/interface_definition.rnc
+++ b/data/schemata/interface_definition.rnc
@@ -142,7 +142,7 @@ valueHelp = element valueHelp
 
 # completionHelp tags contain information about allowed values of a node that is used for generating
 # tab completion in the CLI frontend and drop-down lists in GUI frontends
-# It is only meaninful for leaf nodes
+# It is only meaningful for leaf nodes
 # Allowed values can be given as a fixed list of values (e.g. <list>foo bar baz</list>),
 # as a configuration path (e.g. <path>interfaces ethernet</path>),
 # or as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>

--- a/data/schemata/interface_definition.rng
+++ b/data/schemata/interface_definition.rng
@@ -241,7 +241,7 @@
   <!--
     completionHelp tags contain information about allowed values of a node that is used for generating
     tab completion in the CLI frontend and drop-down lists in GUI frontends
-    It is only meaninful for leaf nodes
+    It is only meaningful for leaf nodes
     Allowed values can be given as a fixed list of values (e.g. <list>foo bar baz</list>),
     as a configuration path (e.g. <path>interfaces ethernet</path>),
     or as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>

--- a/data/schemata/op-mode-definition.rnc
+++ b/data/schemata/op-mode-definition.rnc
@@ -96,7 +96,7 @@ command = element command
 
 # completionHelp tags contain information about allowed values of a node that is used for generating
 # tab completion in the CLI frontend and drop-down lists in GUI frontends
-# It is only meaninful for leaf nodes
+# It is only meaningful for leaf nodes
 # Allowed values can be given as a fixed list of values (e.g. <list>foo bar baz</list>),
 # as a configuration path (e.g. <path>interfaces ethernet</path>),
 # or as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>

--- a/data/schemata/op-mode-definition.rng
+++ b/data/schemata/op-mode-definition.rng
@@ -132,7 +132,7 @@
   <!--
     completionHelp tags contain information about allowed values of a node that is used for generating
     tab completion in the CLI frontend and drop-down lists in GUI frontends
-    It is only meaninful for leaf nodes
+    It is only meaningful for leaf nodes
     Allowed values can be given as a fixed list of values (e.g. <list>foo bar baz</list>),
     as a configuration path (e.g. <path>interfaces ethernet</path>),
     or as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>

--- a/src/commit.ml
+++ b/src/commit.ml
@@ -191,7 +191,7 @@ let config_result_update c_data n_data =
         [Tree_alg.Nonexistent_child] non reachable
      *)
     match n_data.reply with
-    | None -> c_data (* already exluded in calling function *)
+    | None -> c_data (* already excluded in calling function *)
     | Some r ->
     match r.success, n_data.source with
     | true, ADD ->


### PR DESCRIPTION
## What
Comment/doc-only typo fixes (no code identifiers touched):
- `architecture.md`: `preferrable` → `preferable`; `commited` → `committed`
- `data/schemata/{interface_definition,op-mode-definition}.{rnc,rng}`: `meaninful` → `meaningful` (the `completionHelp` schema comment, both compact + XML forms)
- `src/commit.ml`: `exluded` → `excluded` (inline comment)

## Why
Clears this repo's typos-check hits ahead of the T8490 ruleset pilot active flip. The vyconf protobuf enum `Uncommited_changes` is intentionally NOT touched (it's a wire-level identifier — allowlisted centrally).

Phase-0 CodeRabbit: no findings. Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555) (typos-ruleset pilot, Phase 2 Task 2.4).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ