### PR TITLE
T9169: update for vyos1x-config refactor

### DIFF
--- a/src/commit.ml
+++ b/src/commit.ml
@@ -1,6 +1,7 @@
 module VT = Vyos1x.Vytree
 module CT = Vyos1x.Config_tree
-module CD = Vyos1x.Config_diff
+module DT = Vyos1x.Diff_tree
+module UN = Vyos1x.Union
 module RT = Vyos1x.Reference_tree
 
 exception Commit_error of string
@@ -171,7 +172,7 @@ let legacy_order del_t a b =
     CS.fold shift a (a, b)
 
 let calculate_priority_lists rt diff =
-    let del_tree = CD.get_tagged_delete_tree diff in
+    let del_tree = DT.get_tagged_delete_tree diff in
     let add_tree = CT.get_subtree diff ["add"] in
     let cs_del' = get_commit_set rt del_tree DELETE in
     let cs_add' = get_commit_set rt add_tree ADD in
@@ -184,9 +185,9 @@ let calculate_priority_lists rt diff =
        on failure, deleted paths are added back in, added paths ignored
  *)
 let config_result_update c_data n_data =
-    (* alert exn CD.clone:
+    (* alert exn CT.clone:
         [Vytree.Nonexistent_path] not possible for node_data.path
-       alert exn CD.tree_union:
+       alert exn UN.tree_union:
         [Tree_alg.Incompatible_union] not possible for base root
         [Tree_alg.Nonexistent_child] non reachable
      *)
@@ -203,9 +204,9 @@ let config_result_update c_data n_data =
             | None -> n_data.path
             | Some v -> n_data.path @ [v]
         in
-        let add_tree = (CD.clone[@alert "-exn"]) add (CT.default) path in
+        let add_tree = (CT.clone[@alert "-exn"]) add (CT.default) path in
         let config =
-            (CD.tree_union[@alert "-exn"]) add_tree c_data.config_result
+            (UN.tree_union[@alert "-exn"]) add_tree c_data.config_result
         in
         let result =
             { success = c_data.result.success && true;
@@ -221,9 +222,9 @@ let config_result_update c_data n_data =
             | None -> n_data.path
             | Some v -> n_data.path @ [v]
         in
-        let add_tree = (CD.clone[@alert "-exn"]) sub (CT.default) path in
+        let add_tree = (CT.clone[@alert "-exn"]) sub (CT.default) path in
         let config =
-            (CD.tree_union[@alert "-exn"]) add_tree c_data.config_result
+            (UN.tree_union[@alert "-exn"]) add_tree c_data.config_result
         in
         let result =
             { success = c_data.result.success && false;
@@ -261,11 +262,11 @@ let commit_update c_data =
     in List.fold_left func c_data c_data.node_list
 
 let make_commit_data ?(dry_run=false) rt at wt id pid sudo_user user =
-    (* alert exn CD.diff_tree:
+    (* alert exn DT.diff_tree:
         [Config_diff.Incommensurable] not possible as base root
         [Config_diff.Empty_comparison] not reachable for path []
      *)
-    let diff = (CD.diff_tree[@alert "-exn"]) [] at wt in
+    let diff = (DT.diff_tree[@alert "-exn"]) [] at wt in
     let del_list, add_list = calculate_priority_lists rt diff in
     { session_id = id;
       session_pid = pid;

--- a/src/session.ml
+++ b/src/session.ml
@@ -1,7 +1,9 @@
 module CT = Vyos1x.Config_tree
 module IC = Vyos1x.Internal.Make(CT)
 module CC = Commitd_client.Commit
-module CD = Vyos1x.Config_diff
+module DT = Vyos1x.Diff_tree
+module DS = Vyos1x.Diff_show
+module UN = Vyos1x.Union
 module VT = Vyos1x.Vytree
 module VL = Vyos1x.Vylist
 module RT = Vyos1x.Reference_tree
@@ -179,11 +181,11 @@ let update_delete w s changeset path =
     (op :: changeset)
 
 let get_changeset w s lt rt =
-    (* alert exn CD.diff_tree:
+    (* alert exn DT.diff_tree:
         [Config_diff.Incommensurable] not possible for base root
         [Config_diff.Empty_comparison] not possible for empty path
      *)
-    let diff = (CD.diff_tree[@alert "-exn"]) [] lt rt in
+    let diff = (DT.diff_tree[@alert "-exn"]) [] lt rt in
     let add_tree = CT.get_subtree diff ["add"] in
     let del_tree = CT.get_subtree diff ["del"] in
     let add_changeset =
@@ -375,12 +377,12 @@ let session_changed w s =
     (* structural equality test requires consistent ordering, which is
      * practised, but may be unreliable; test actual difference
      *)
-    (* alert exn CD.diff_tree:
+    (* alert exn DT.diff_tree:
         [Config_diff.Incommensurable] not possible for base root
         [Config_diff.Empty_comparison] not possible for empty path
      *)
     let c = get_proposed_config w s in
-    let diff = (CD.diff_tree[@alert "-exn"]) [] w.running_config c in
+    let diff = (DT.diff_tree[@alert "-exn"]) [] w.running_config c in
     let add_tree = CT.get_subtree diff ["add"] in
     let del_tree = CT.get_subtree diff ["del"] in
     (del_tree <> CT.default) || (add_tree <> CT.default)
@@ -405,7 +407,7 @@ let load w s file cached =
         { s with changeset = get_changeset w s w.running_config config; }
 
 let merge w s file destructive =
-    (* alert exn CD.tree_merge:
+    (* alert exn UN.tree_merge:
         [Tree_alg.Incompatible_union] not possible for base root
         [Tree_alg.Nonexistent_child] not reachable
      *)
@@ -416,7 +418,7 @@ let merge w s file destructive =
         let () = validate_tree w config in
         let proposed = get_proposed_config w s in
         let merged =
-            (CD.tree_merge[@alert "-exn"]) ~destructive:destructive proposed config
+            (UN.tree_merge[@alert "-exn"]) ~destructive:destructive proposed config
         in
         { s with changeset = get_changeset w s w.running_config merged; }
 
@@ -650,7 +652,7 @@ let show_config w s path =
     then raise (Session_error "Path does not exist")
     else
     let res =
-        (CD.diff_show[@alert "-exn"])
+        (DS.diff_show[@alert "-exn"])
         w.reference_tree
         path_show
         w.running_config


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Simple update for changes in
https://github.com/vyos/vyos1x-config/pull/90

This PR depends on that refactoring.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/90

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
